### PR TITLE
Code polish

### DIFF
--- a/bundler/_p_hotAssetsServer.js
+++ b/bundler/_p_hotAssetsServer.js
@@ -12,7 +12,20 @@ new WebpackDevServer(
     contentBase: 'backend/servers/$[frontend.serverName]/app/templates/',
     hot: true,
     historyApiFallback: true,
-    publicPath: config.output.publicPath
+    publicPath: config.output.publicPath,
+
+    // provide less noisy output from webpack
+    quiet: false,
+    noInfo: false,
+    stats: {
+      assets: false,
+      colors: true,
+      version: false,
+      hash: false,
+      timings: false,
+      chunks: false,
+      chunkModules: false
+    }
   }
 ).listen(PORT, HOST, function (err, result) {
   if (err) {

--- a/bundler/dev.config.js
+++ b/bundler/dev.config.js
@@ -1,7 +1,7 @@
 const webpack = require('webpack')
 const config = require('./config')
 
-const HOST = '0.0.0.0'
+const HOST = '0.0.0.0' // so we can test the project remotely over the same network
 const PORT = 3000
 
 const hotAssetsServer = {


### PR DESCRIPTION
Minor things.

---
Other questions I have: @Ledoux @franblas 

1. why are we using `_p_` prefixes for certain webpack files? to consider them "partials"? I'm not sure  I think it's a good idea, there's not such a big difference between these files and the non prefixed ones.
2. why are the bundle commands in bin folder? given that they are node commands and not very long, I would just keep them in the package.json..
3. what is `teleport.json`? I don't see any documentation for it. Is it autogenerated? can the user configure it?
4. the `backend/servers/frontend-server/app/templates` files are a bit weird. what's the benefit of keeping them as html files when they are almost empty, over just defining them inline in some relevant JS code? I presume they're not re-used in multiple different contexts?

---
On my wish list (later - let's _not_ block for these)
* GZIP size reported for CSS as well, and diffing between new size and previous (unless first build)
* Webpack 2