### PR TITLE
replaced localhost by development type

### DIFF
--- a/bin/development_bundle.sh
+++ b/bin/development_bundle.sh
@@ -1,0 +1,1 @@
+NODE_ENV=webpack node ./bundler/webpackDevServer.js

--- a/bin/localhost_bundle.sh
+++ b/bin/localhost_bundle.sh
@@ -1,1 +1,0 @@
-NODE_ENV=webpack node ./bundler/hotAssetsServer.js


### PR DESCRIPTION
in the new version of teleport, "localhost" type will be replaced by "development"...
so we need to change the file name also here :p.